### PR TITLE
Retrieve IDBObjectStore by objectStore name rather than database name

### DIFF
--- a/indexeddb-ajax.html
+++ b/indexeddb-ajax.html
@@ -77,7 +77,7 @@
 			if(this.db){
 				if(this.columns.length>0){
 					var self = this;
-					var objectStore = this.db.transaction([self.dbName], "readonly").objectStore(self.dbStoreName);
+					var objectStore = this.db.transaction([self.dbStoreName], "readonly").objectStore(self.dbStoreName);
 					var index;
 					if(this.sortColumn) objectStore = objectStore.index(this.sortColumn);
 					var skip = this.start;


### PR DESCRIPTION
When retrieving an `IDBObjectStore`, the `IDBDatabase.transaction` method should take the name/names of one or more objectStores rather than the name of the parent database as the first parameter.  

Reference:  https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase.transaction#Parameters and here: https://msdn.microsoft.com/en-us/library/ie/hh772509(v=vs.85).aspx

NOTE:  The Mozilla example code makes this confusing since it uses the same name ("todoList") for both the database and for the objectStore