### PR TITLE
2nd instance of using dbName instead of dbStoreName

### DIFF
--- a/indexeddb-ajax.html
+++ b/indexeddb-ajax.html
@@ -58,7 +58,7 @@
 
 				objectStore.transaction.oncomplete = function(event) {
 					// Store values in the newly created objectStore.
-					var innerObjectStore = db.transaction(self.dbName, "readwrite").objectStore(self.dbStoreName);
+					var innerObjectStore = db.transaction(self.dbStoreName, "readwrite").objectStore(self.dbStoreName);
 					response.forEach(function(element){
 						innerObjectStore.add(element);
 					});


### PR DESCRIPTION
Different line but the same issue as in commit da98e86228a1263e1ee8112c1d2a8c6f938787d9 and PR https://github.com/stevenrskelton/sortable-table/pull/36 

The previous commit only addressed a refresh with the same dbVersion.  However, when the dbVersion is updated, this code gets called and throws an object not found error.  As before, passing the dbStoreName instead of the dbName corrects the issue.

Also, I've double checked to make sure there are no more instances of this specific issue.
